### PR TITLE
Make terraform init work

### DIFF
--- a/apps.tf
+++ b/apps.tf
@@ -2,7 +2,7 @@ module "apps" {
   for_each = var.apps
 
   source  = "cloudchacho/taskhawk-queue/google"
-  version = "~> 3.6.0"
+  version = "~> 4.6.0"
 
   queue                = each.key
   iam_service_accounts = each.value.service_accounts

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,6 @@
 terraform {
   required_version = ">= 0.15, <2"
 
-  experiments = [module_variable_optional_attrs]
 
   required_providers {
     google = ">= 3.16.0"


### PR DESCRIPTION
Hiyeee cloudcacho! I tried to tidy up some bits so `terraform init` works.

Details

For the `cloudchacho/taskhawk/google` and `git::https://github.com/cloudchacho/terraform-google-taskhawk` module references, I get the following error:

```
$ cat main.tf
# ...
terraform {
  required_version = ">= 1.3.0"
}

module "taskhawk" {
  # source   = "cloudchacho/taskhawk/google"
  source   = "git::https://github.com/cloudchacho/terraform-google-taskhawk"
  # source   = "git::https://github.com/max-augmodo/terraform-google-taskhawk?ref=exp"

  apps = {
    maxhax = {
      labels = {
        app = "maxhax",
        env = "playground"
      }
    }
  }
}

$ terraform init
# ...
│ Error: Module uses experimental features
│
│   on .terraform/modules/taskhawk.apps/modules/queue/versions.tf line 4, in terraform:
│    4:   experiments = [module_variable_optional_attrs]
│
│ Experimental features are intended only for gathering early feedback on new
│ language designs, and so are available only in alpha releases of Terraform.
╵

$ terraform -version
Terraform v1.13.4
on darwin_arm64
+ provider registry.terraform.io/hashicorp/google v7.5.0
```

To resolve, I removed the [module_variable_optional_attrs](https://github.com/hashicorp/terraform/issues/31692#issuecomment-1260639316) experiment and bumped the taskhawk-queue version.